### PR TITLE
Fix if*/elif* highlighting

### DIFF
--- a/rpm-specfile.js
+++ b/rpm-specfile.js
@@ -36,7 +36,7 @@ function hljsDefineRpmSpecfile(hljs) {
         },
         {
             className: "link",
-            begin: /(%)(if|ifarch|ifnarch|ifos|ifnos|elif|elifarch|elifos|else|endif)/,
+            begin: /(%)(ifarch|ifnarch|ifos|ifnos|if|elifarch|elifos|elif|else|endif)/,
         },
         {
             className: "link",


### PR DESCRIPTION
A regular expression with alternation will take the first match
that succeeds, so if 'if' comes before 'ifarch', 'ifos', etc. then
the longer matches will never even be checked.