### PR TITLE
Style builtins as 'built_in', expand list

### DIFF
--- a/rpm-specfile.js
+++ b/rpm-specfile.js
@@ -35,8 +35,8 @@ function hljsDefineRpmSpecfile(hljs) {
             begin: /(%)(?:package|prep|generate_buildrequires|sourcelist|patchlist|build|description|install|verifyscript|clean|changelog|check|pre[a-z]*|post[a-z]*|trigger[a-z]*|files)/,
         },
         {
-            className: "link",
-            begin: /(%)(if|ifarch|ifnarch|ifos|ifnos|elif|elifarch|elifos|else|endif)/,
+            className: "built_in",
+            begin: /(%)(if|ifarch|ifnarch|ifos|ifnos|elif|elifarch|elifos|else|endif|bcond_(with|without)|bcond|define|global)/,
         },
         {
             className: "link",


### PR DESCRIPTION
IMHO not everything can be styled as a 'link'. This PR changes styling for fundamental RPM syntax like `%if*`, `%elif*`, `%else`, etc. to 'built_in' which IMHO is more appropriate. In the GitHub theme, they'll be styled `#0086b3`.

It also adds more commands, like `%define`/`%global` and the `%bcond*` family, to that list.

This will conflict with my other PR, so if you want to accept both I'll have to fix up the second after you accept one of them. No biggie.