### PR TITLE
Style heading-like markers as 'section'

### DIFF
--- a/rpm-specfile.js
+++ b/rpm-specfile.js
@@ -31,7 +31,7 @@ function hljsDefineRpmSpecfile(hljs) {
             begin:  /^(Name|BuildRequires|BuildConflicts|Version|Release|Epoch|Summary|Group|License|Packager|Vendor|Icon|URL|Distribution|Prefix|Patch[0-9]*|Source[0-9]*|Requires\(?[a-z]*\)?|[a-zA-Z]+Req|Obsoletes|Recommends|Suggests|Supplements|Enhances|Provides|Conflicts|RemovePathPostfixes|Build[a-zA-Z]+|[a-zA-Z]+Arch|Auto[a-zA-Z]+)(:)/,
         },
         {
-            className: "keyword",
+            className: "section",
             begin: /(%)(?:package|prep|generate_buildrequires|sourcelist|patchlist|build|description|install|verifyscript|clean|changelog|check|pre[a-z]*|post[a-z]*|trigger[a-z]*|files)/,
         },
         {


### PR DESCRIPTION
In the GitHub theme, this will make them bold and red, so they really stand out. As is appropriate for strings that fundamentally divide the various portions of the specfile contents.