### PR TITLE
Add 'name' attribute

### DIFF
--- a/rpm-specfile.js
+++ b/rpm-specfile.js
@@ -21,6 +21,7 @@ var module = module ? module : {};     // shim for browser use
 
 function hljsDefineRpmSpecfile(hljs) {
   return {
+    name: "rpm-specfile",
     aliases: ['rpm', 'spec', 'rpm-spec', 'specfile'],
     contains: [
         hljs.COMMENT('%dnl'),


### PR DESCRIPTION
Since highlightjs/highlight.js#2400 (merged as https://github.com/highlightjs/highlight.js/commit/65d46b34f2b91c04c5663061302e69b9320be3cd), a 'name' attribute is supported for language grammars.